### PR TITLE
Updating revolt to properly require the rx-node module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/kevinswiber/revolt",
   "dependencies": {
     "rx": "^2.3.18",
+    "rx-node": "^1.0.0",
     "ws": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revolt",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A reactive, pipelined HTTP client.",
   "main": "revolt.js",
   "directories": {

--- a/revolt.js
+++ b/revolt.js
@@ -3,6 +3,7 @@ var https = require('https');
 var Stream = require('stream').Stream;
 var url = require('url');
 var Rx = require('rx');
+Rx.Node = require('rx-node');
 var WebSocket = require('ws');
 var Builder = require('./builder');
 


### PR DESCRIPTION
Requiring rx-node to account for the reactive extensions refactoring.
